### PR TITLE
Update Cannon - making AB standard legal

### DIFF
--- a/packages/core/src/assets/xwa/upgrades/cannon.ts
+++ b/packages/core/src/assets/xwa/upgrades/cannon.ts
@@ -134,7 +134,7 @@ const t: UpgradeBase[] = [
       },
     ],
     cost: { value: 7 },
-    standard: false,
+    standard: true,
     epic: true,
     extended: true,
   },


### PR DESCRIPTION
Changed Autoblasters to standard: true for xwa points.