### PR TITLE
Tristan Wren usable with Gar Saxon

### DIFF
--- a/packages/core/src/assets/xwa/upgrades/crew.ts
+++ b/packages/core/src/assets/xwa/upgrades/crew.ts
@@ -2142,7 +2142,7 @@ const t: UpgradeBase[] = [
     ],
     standard: true,
     epic: true,
-    restrictions: [{ factions: ['Rebel Alliance'] }],
+    restrictions: [{ factions: ['Rebel Alliance'], character: ['Gar Saxon'] }],
     extended: true,
   },
   {


### PR DESCRIPTION
Added qualifier to allow Tristan Wren in lists with Gar Saxon as per card